### PR TITLE
Update installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 1. Run following commands:
 
 ```fish
-curl --silent --show-error --location https://git.io/fish-plug | source
-plug install kidonng/plug.fish
+curl -silent --show-error --location https://raw.githubusercontent.com/kidonng/plug.fish/v2/functions/plug.fish | source
+PLUG_GIT='--depth 1 -q --branch v2' plug install kidonng/plug.fish
 ```
 
 2. Add the following commands to the top of `~/.config/fish/config.fish`:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 1. Run following commands:
 
 ```fish
-curl -silent --show-error --location https://raw.githubusercontent.com/kidonng/plug.fish/v2/functions/plug.fish | source
+curl --silent --show-error --location https://raw.githubusercontent.com/kidonng/plug.fish/v2/functions/plug.fish | source
 PLUG_GIT='--depth 1 -q --branch v2' plug install kidonng/plug.fish
 ```
 


### PR DESCRIPTION
If you plan to maintain the `v2` branch for any length of time then it's worth updating the installation commands. The `git.io` URL currently returns a `404` and it may not be possible to resurrect given the [git.io deprecation](https://github.blog/changelog/2022-04-25-git-io-deprecation/). The `plug install` command attempts to install from the default branch, which is currently the `v3` rewrite, and this causes issues during installation. I've updated both commands here in an attempt to help maintain the `v2` branch.